### PR TITLE
Fixed the subaccounts endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 - [Compare to latest release][unreleased]
 
+## [1.5.1] - 2020-10-28
+### Fixed
+- [#3](https://github.com/Radico/python-sparkpost/pull/3) Fixed Subaccounts endpoint
+
+## [1.5.0] - 2020-10-26
+### Added
+- [#2](https://github.com/Radico/python-sparkpost/pull/2) Subaccounts endpoint
+
+## [1.4.0] - 2020-10-26
+### Added
+- [#1](https://github.com/Radico/python-sparkpost/pull/1) SendingDomains and TrackingDomains endpoints
+
 ## [1.3.6] - 2018-03-23
 ### Added
 - [#160](https://github.com/SparkPost/python-sparkpost/pull/160) Extra header support for Django messages

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst', 'r', 'utf-8') as f:
 
 setup(
     name='sparkpost',
-    version='1.5.0',
+    version='1.5.1',
     author='SparkPost',
     author_email='developers@sparkpost.com',
     packages=find_packages(),

--- a/sparkpost/subaccounts.py
+++ b/sparkpost/subaccounts.py
@@ -5,10 +5,11 @@ from .base import Resource
 class Subaccounts(Resource):
     """
     Domains class for managing subaccounts.
-    For detailed request and response formats, see the 
+    For detailed request and response formats, see the
     `Subaccounts API documentation
     <https://developers.sparkpost.com/api/subaccounts/>`.
     """
+    key = 'subaccounts'
 
     def create(self, **kwargs):
         """
@@ -16,7 +17,7 @@ class Subaccounts(Resource):
         :param str name: subaccount name
         :param str ip_pool: ID of an IP Pool in which to restrict this subaccount's mail deliveries
         :param bool setup_api_key: Whether or not to create an API key for the subaccount.
-        :param str key_label: User friendly identifier for the initial subaccount api key. 
+        :param str key_label: User friendly identifier for the initial subaccount api key.
         :param list key_grants: List of grants to give to the initial subaccount api key.
         :param list key_valid_ips: List of IP's that the initial subaccount API key can be used from.
         :returns: Subaccount's ID, along with the API key and API key label, if one was created.
@@ -54,7 +55,7 @@ class Subaccounts(Resource):
         :param str name: subaccount name
         :param str status: Status of the subaccount
         :param str ip_pool: ID of an IP Pool in which to restrict this subaccount's mail deliveries
-        
+
         :returns: Message detailing the success of the operation.
         :raises: :exc:`SparkPostAPIException` if API call fails
         """


### PR DESCRIPTION
Fixed the subaccounts endpoint to provide the key of 'subaccounts' when creating the uri for a request